### PR TITLE
Create chassis resources with secrets too

### DIFF
--- a/pkg/butler/configure.go
+++ b/pkg/butler/configure.go
@@ -93,7 +93,7 @@ func (b *Butler) configureAsset(config []byte, asset *asset.Asset) (err error) {
 
 		//Setup a resource instance
 		//Get any templated values in the asset config rendered
-		resourceInstance := resource.Resource{Log: log, Asset: asset}
+		resourceInstance := resource.Resource{Log: log, Asset: asset, Secrets: b.Secrets}
 
 		renderedConfig := resourceInstance.LoadConfigResources(config)
 		if renderedConfig == nil {


### PR DESCRIPTION
We were doing it for servers but not for chassis. Because of this
rendering a chassis configuration template with secret lookup was
failing with unknown identifier error for lookup_secret function.