### PR TITLE
Prevent leak of vault token in readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,16 +113,17 @@ To setup secrets lookup from Vault,
 
 Examples
 
-Set credentials in Vault
+Set credentials in Vault, using `--config` and command substitution to prevent leaking the vault token
+to other processes (command line arguments are visible to all processes).
 ```
-curl -H "X-Vault-Token: $VAULT_TOKEN" \
+curl --config <( builtin printf 'header = "X-Vault-Token: %s"' "${VAULT_TOKEN}" ) \
     -H "Content-Type: application/json" \
     -X POST -d '{"Administrator": "hunter2", "Ops": "foobar"}' https://vault.example.com/v1/secret/baremetal/bmc
 ```
 
 Check credentials were set
 ```
-curl --header "X-Vault-Token: $VAULT_TOKEN" \
+curl --config <( builtin printf 'header = "X-Vault-Token: %s"' "${VAULT_TOKEN}" ) \
       -X GET https://vault.example.com/v1/secret/baremetal/bmc
 ```
 


### PR DESCRIPTION
## Why
Command line arguments are visible to all processes, so by supplying
`--header X-Vault-Token: TOKEN` on the command line will make the vault
token visible to all processes on the system. We don't want this, so use
command substitution.

## How
By using `<( )`, and `--config`, curl will treat the header as a file,
and hence will not be supplied as a command line argument visible to
other processes. `builtin printf` is used so bash ensures its internal
printf is used instead of `/usr/bin/printf`.